### PR TITLE
大佬，发现您的项目引入了org.apache.commons:commons-compress@1.20组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -284,7 +282,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Commons Compress 安全漏洞
缺陷组件：org.apache.commons:commons-compress@1.20
漏洞编号：CVE-2021-35517
漏洞描述：Apache Commons Compress是美国阿帕奇（Apache）基金会的一个用于处理压缩文件的库。
Apache Commons Compress存在资源管理错误漏洞，该漏洞源于当读取特殊设计的TAR归档文件时，Compress可以分配大量内存，从而导致小输入出现内存不足错误。
影响范围：[1.1, 1.21)
最小修复版本：1.21
缺陷组件引入路径：com.base:backend-api@0.0.1-SNAPSHOT->org.apache.commons:commons-compress@1.20
```
另外我运行这个项目时，IDE的安全插件提示还有58个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p2335c